### PR TITLE
feat: Setup SSH for the VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 **/worker0
 **/worker1
 **/worker2
+**/vm-ssh-key.pub
+**/vm-ssh-key

--- a/vms/cloud-init/user-data.control
+++ b/vms/cloud-init/user-data.control
@@ -1,2 +1,8 @@
 #cloud-config
-password: ubuntu
+ssh_authorized_keys:
+    - $(<./vm-ssh-key.pub)
+packages:
+    - curl
+package_update: true
+package_upgrade: true
+package_reboot_if_required: false

--- a/vms/cloud-init/user-data.gateway
+++ b/vms/cloud-init/user-data.gateway
@@ -1,2 +1,8 @@
 #cloud-config
-password: ubuntu
+ssh_authorized_keys:
+    - $(<$(pwd)/vm-ssh-key.pub)
+packages:
+    - curl
+package_update: true
+package_upgrade: true
+package_reboot_if_required: false

--- a/vms/cloud-init/user-data.worker
+++ b/vms/cloud-init/user-data.worker
@@ -1,2 +1,5 @@
 #cloud-config
-password: ubuntu
+ssh_authorized_keys:
+    - $(<./vm-ssh-key.pub)
+packages:
+    - curl

--- a/vms/definitions
+++ b/vms/definitions
@@ -13,3 +13,13 @@ get_vm_name() {
         echo worker$((id-4))
     fi
 }
+
+get_inets() {
+    inets=()
+    for ((i=0;i<7;i++))
+    do
+        inets[i]=192.168.200.$((i+3))
+    done
+
+    echo "${inets[*]}"
+}

--- a/vms/setup-dnsmasq
+++ b/vms/setup-dnsmasq
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+dir=$(dirname "$0")
+
 HOMEBREW_PREFIX=${HOMEBREW_PREFIX:-/opt/homebrew}
 
 base_dnsmasq_conf="$HOMEBREW_PREFIX/etc/dnsmasq.conf"
@@ -10,11 +12,9 @@ k8s_dnsmasq_conf="$(pwd)/dnsmasq.conf"
 if_inet=192.168.200.1
 export dhcp_ranges=(192.168.200.2 192.168.200.10)
 
+source "$dir/definitions"
 export host_inets=()
-for ((i=0;i<7;i++))
-do
-    host_inets[i]=192.168.200.$((i+3))
-done
+read -r -a host_inets < <(get_inets)
 
 export kube_api_inet=192.168.200.11
 

--- a/vms/setup-ssh
+++ b/vms/setup-ssh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(dirname "$0")
+
+source "$dir/definitions"
+
+vm_id="$1"
+
+inets=()
+read -r -a inets < <(get_inets)
+
+vm_inet=${inets[vm_id]}
+
+until nc -zw 10 "$vm_inet" 22; do sleep 1; done
+
+vm_name=$(get_vm_name "$vm_id")
+# Remove the stale entries for a given VM.
+if [[ -f ~/.ssh/known_hosts ]]; then
+    sed -i '' "/^$vm_name/d" ~/.ssh/known_hosts
+fi
+
+ssh-keyscan "$vm_inet" 2> /dev/null >> ~/.ssh/known_hosts
+
+until ssh "ubuntu@$vm_inet" -i "$dir/vm-ssh-key" exit; do sleep 1; done

--- a/vms/setup-vm
+++ b/vms/setup-vm
@@ -4,7 +4,7 @@ set -e
 dir=$(dirname "$0")
 
 # Grab the helper script.
-source "$dir/helpers"
+source "$dir/definitions"
 
 # Download the cloud image, if it does not exist.
 img_name="ubuntu-24.04.img"


### PR DESCRIPTION
`cloud-init` scripts are updated to contain the public SSH key pair generated for the VMs, called `vm-ssh-key[.pub]`.

A new file called `setup-ssh` is implemented to automate the SSH configuration, meaning that the stale entries in `known_hosts` are removed whenever this script is executed after the VM is booted up.

Also, the `helpers` script is renamed to `definitions` to better suit the usage of the script.

Since SSH setup needs inet configurations as well, these definitions are moved under the `definitions` script.

--- 

- The key pair generation will be added to the README later on.
- The names and locations of the scripts will be updated once the project is finalized. Changing structures during the project may not worth the effort.