### PR TITLE
feat: Automate launching all VMs for the cluster

### DIFF
--- a/vms/launch-all
+++ b/vms/launch-all
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(dirname "$0")
+
+source "$dir/definitions"
+
+tmux_session_name="$1"
+if [[ -z "$tmux_session_name" ]]; then
+    echo "usage: $(basename "$0") <tmux-session-name>" >&2
+    exit 1
+fi
+
+tmux new-session -s "$tmux_session_name" -n qemu -d
+
+for vm_id in {0..6}; do
+    "$dir/setup-vm" "$vm_id"
+    tmux send-keys -t "$tmux_session_name" "cd $dir" C-m
+    tmux send-keys -t "$tmux_session_name" "vm_id=$vm_id; vm_name=$(get_vm_name "$vm_id")" C-m
+    tmux send-keys -t "$tmux_session_name" "./launch-vm $vm_id" C-m
+
+    if [[ $vm_id != 6 ]]; then
+        tmux split-window -t "$tmux_session_name" -v
+    fi
+    tmux select-layout -t "$tmux_session_name" tiled
+done

--- a/vms/launch-vm
+++ b/vms/launch-vm
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(dirname "$0")
+
+source "$dir/definitions"
+
+vm_id=$1
+vm_name=$(get_vm_name "$vm_id")
+vm_dir="$dir/$vm_name"
+
+# The QEMU command.
+mac="52:52:52:00:00:0$vm_id"
+
+/opt/homebrew/opt/socket_vmnet/bin/socket_vmnet_client \
+  /opt/homebrew/var/run/socket_vmnet \
+  qemu-system-aarch64 \
+  -nographic \
+  -machine virt,highmem=on \
+  -accel hvf \
+  -cpu host \
+  -smp 2 \
+  -m 2G \
+  -device virtio-net-pci,netdev=k8snet,mac="$mac" \
+  -netdev socket,id=k8snet,fd=3 \
+    -bios /opt/homebrew/share/qemu/edk2-aarch64-code.fd \
+    -hda "$vm_dir/disk.img" \
+    -drive file="$vm_dir/cidata.iso",driver=raw,if=virtio


### PR DESCRIPTION
2 scripts are implemented for this feature:

- `launch-vm`, which creates and executes the necessary QEMU command for a given VM. The script takes an ID as an argument.

- `launch-all` which uses `launch-vm` and creates a new tmux session based on the given <session-name> argument. Then, it executes `launch-vm` in the session and splits the window into panes, essentially creating 7 panes in the session window.

In order for this script to work, the network infrastructure for the VMs should be created with:

```
sudo ./setup-dnsmasq
```

first.

---

- As a note to self, the installation and initial setup of `vmnet-socket` should be written in README for the features implemented in this PR.