### PR TITLE
feat: Automate SSH connections to all VMs in the cluster

### DIFF
--- a/vms/definitions
+++ b/vms/definitions
@@ -14,12 +14,21 @@ get_vm_name() {
     fi
 }
 
+inet_nw_bits=192.168.200
+
 get_inets() {
     inets=()
     for ((i=0;i<7;i++))
     do
-        inets[i]=192.168.200.$((i+3))
+        inets[i]=$inet_nw_bits.$((i+3))
     done
 
     echo "${inets[*]}"
+}
+
+get_ssh_cmd() {
+    vm_id="$1"
+
+    dir=$(dirname "$0")
+    echo "ssh ubuntu@$inet_nw_bits.$((vm_id+3)) -i $dir/vm-ssh-key"
 }

--- a/vms/ssh-all
+++ b/vms/ssh-all
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(dirname "$0")
+
+tmux_session_name="$1"
+if [[ -z "$tmux_session_name" ]]; then
+    echo "usage: $(basename "$0") <tmux-session-name>" >&2
+    exit 1
+fi
+
+for vm_id in {0..6}; do
+    "$dir/setup-ssh" "$vm_id"
+done
+
+source "$dir/definitions"
+
+# Gateway SSH session.
+tmux new-session -s "$tmux_session_name" -n "kubenet-ssh-gateway" -d
+tmux send-keys -t "$tmux_session_name" "$(get_ssh_cmd 0)" C-m
+
+# Create custom tmux windows for other VM "groups"
+ssh_window() {
+    local win_name="$1"
+    local first_vm_id="$2"
+    local last_vm_id="$3"
+    local pane_layout="$4"
+
+    tmux new-window -t "$tmux_session_name" -n "$win_name"
+    for vm_id in $(seq "$first_vm_id" "$last_vm_id"); do
+        tmux send-keys -t "$tmux_session_name" "$(get_ssh_cmd "$vm_id")" C-m
+
+        if [[ "$vm_id" != "$last_vm_id" ]]; then
+            tmux split-window -t "$tmux_session_name" -v
+        fi
+
+        tmux select-layout -t "$tmux_session_name" "$pane_layout"
+    done
+}
+
+# A window with SSH connections to "control" VMs.
+ssh_window ssh-controls 1 3 even-vertical
+
+# A window with SSH connections to "worker" VMs.
+ssh_window ssh-workers 4 6 even-vertical
+
+# A window with SSH connections to both "control" and "worker" VMs.
+ssh_window ssh-controls 1 6 tiled
+
+# Attach to the created tmux session, "control" window.
+tmux attach -t "$tmux_session_name:ssh-controls"


### PR DESCRIPTION
A new script called `ssh-all` is written to create another tmux session along with the `qemu` session holding our VMs.

This session contains three different windows, each representing our "groups" in the cluster:

- One for "control" VMs
- One for "worker" VMs
- One for both "control" and "worker" VMs

The helper function `get_ssh_cmd` is added to definitions as well.