### PR TITLE
fix: Fix invalid CA CSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # The .kubeconfig files.
 **/*.kubeconfig
+
+# The encryption configuration which is used by kube-apiserver to encrypt the data stored in etcd.
+**/encryption-config.yaml

--- a/certs/ca-config.json
+++ b/certs/ca-config.json
@@ -8,7 +8,7 @@
         "usages": [
           "signing",
           "key encipherment",
-          "server-auth",
+          "server auth",
           "client auth"
         ],
         "expiry": "87600h"

--- a/certs/deploy
+++ b/certs/deploy
@@ -10,7 +10,6 @@ for i in {0..2}; do
     vm_name="control$i"
     vm_id=$(get_vm_id "$vm_name")
 
-    echo "$dir"
     scp \
         -i "$(get_ssh_key_path)" \
         "$dir/ca.pem" \
@@ -34,7 +33,6 @@ for i in {0..2}; do
     vm_name="worker$i"
     vm_id=$(get_vm_id "$vm_name")
 
-    echo "$dir"
     scp \
         -i "$(get_ssh_key_path)" \
         "$dir/ca.pem" \


### PR DESCRIPTION
The invalid `server-auth` field caused `etcd` to fail the TLS handshake between its peers.

Therefore, the CA CSR is updated with the correct field `server auth`.

Also, `.gitignore` is updated with the encryption configuration that is used by `kube-apiserver`.