### PR TITLE
feat: Configure LB for control-plane nodes through gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,13 @@
 **/ubuntu-24.04.img
 
 # Directories holding the base cloud image + `cloud-init` ISO for each VM.
-**/gateway
-**/control0
-**/control1
-**/control2
-**/worker0
-**/worker1
-**/worker2
+**/vms/gateway
+**/vms/control0
+**/vms/control1
+**/vms/control2
+**/vms/worker0
+**/vms/worker1
+**/vms/worker2
 
 # The SSH keys generated for VM SSH access.
 **/vm-ssh-key.pub

--- a/certs/admin-csr.json
+++ b/certs/admin-csr.json
@@ -8,7 +8,7 @@
     {
       "C": "Country",
       "L": "Location",
-      "O": "kubenet-org",
+      "O": "system:masters",
       "OU": "kubenet",
       "ST": "State"
     }

--- a/certs/generate
+++ b/certs/generate
@@ -66,7 +66,7 @@ kubeconfigs() {
         kubectl config set-cluster kubenet \
             --certificate-authority="$dir/ca.pem" \
             --embed-certs=true \
-            --server=https://kubernetes:6443 \
+            --server=https://192.168.200.11:6443 \
             --kubeconfig="$kubeconfig"
 
         kubectl config set-credentials "$user" \

--- a/certs/setup-local-kubeconfig
+++ b/certs/setup-local-kubeconfig
@@ -7,7 +7,7 @@ dir=${BASH_SOURCE%/*}
 kubectl config set-cluster kubenet \
     --certificate-authority="$dir/ca.pem" \
     --embed-certs=true \
-    --server=https://localhost:6443
+    --server=https://192.168.200.11:6443
 
 kubectl config set-credentials admin \
     --client-certificate="$dir/admin.pem" \

--- a/definitions
+++ b/definitions
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+arch=arm64
+k8s_version=1.31.4
+
 get_vm_name() {
     id="$1"
     if [[ ! $id =~ ^-?[0-9]+$ ]]; then

--- a/gateway/setup
+++ b/gateway/setup
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "setup: the script must be run as root" >&2
+    exit 1
+fi
+
+while [[ ! -f /etc/ha.d/ldirectord.cf ]]; do
+    echo "setup: waiting for ldirectord to be installed..."
+    sleep 1
+done
+
+cat <<EOF | tee /etc/ha.d/ldirectord.cf
+checktimeout=5
+checkinternal=1
+autoreload=yes
+quiescent=yes
+
+virtual=192.168.200.11:6443
+    servicename=kube-api
+    real=192.168.200.4:6443 gate
+    real=192.168.200.5:6443 gate
+    real=192.168.200.6:6443 gate
+    scheduler=wrr
+    checktype=negotiate
+    service=https
+    request="healthz"
+    receive="ok"
+EOF
+
+systemctl restart ldirectord

--- a/vms/cloud-init/network-config.control
+++ b/vms/cloud-init/network-config.control
@@ -1,0 +1,11 @@
+network:
+    version: 2
+    ethernets:
+        lo:
+            match:
+                name: lo
+            addresses: [192.168.200.11/32]
+        eth:
+            match:
+                name: enp*
+            dhcp4: true

--- a/vms/cloud-init/network-config.gateway
+++ b/vms/cloud-init/network-config.gateway
@@ -1,0 +1,8 @@
+network:
+    version: 2
+    ethernets:
+        eth:
+            match:
+                name: enp*
+            addresses: [192.168.200.11/32]
+            dhcp4: true

--- a/vms/cloud-init/user-data.control
+++ b/vms/cloud-init/user-data.control
@@ -6,3 +6,10 @@ packages:
 package_update: true
 package_upgrade: true
 package_reboot_if_required: false
+write_files:
+    - path: /etc/sysctl.d/50-vip-arp.conf
+    content: |
+        net.ipv4.conf.all.arp_announce = 2
+        net.ipv4.conf.all.arp_ignore = 1
+runcmd:
+    - sysctl -p /etc/sysctl.d/50-vip-arp.conf

--- a/vms/cloud-init/user-data.gateway
+++ b/vms/cloud-init/user-data.gateway
@@ -3,6 +3,12 @@ ssh_authorized_keys:
     - $(<$(pwd)/vm-ssh-key.pub)
 packages:
     - curl
+    - ipvsadm
+    - ldirectord
 package_update: true
 package_upgrade: true
 package_reboot_if_required: false
+ca_certs:
+    trusted:
+        - |
+$(sed "s/^/      /g" "$dir/certs/ca.pem")

--- a/vms/setup-vm
+++ b/vms/setup-vm
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+
 dir=${BASH_SOURCE%/*}
 
 source "$dir/../definitions"


### PR DESCRIPTION
Gateway machine is set up as a load balancer between the control nodes through the virtual IP `192.168.200.11` and a binary called `ldirectord`.

This IP was left outside the DHCP range intentionally, because it is owned by 4 different machines (gateway + control{0..2}). Hence, it becomes a virtual IP.

In order to make gateway the only visible owner of this virtual IP, the ARP request & response messages of control nodes are updated via `cloud-init/network-config.control{0..2}`.

As a temporary solution, the DNS lookup for `192.168.200.11` (kube-api) was disabled, because the default DNS server of the nodes cannot resolve this name as of now (127.0.0.1:53 instead of 192.168.200.1:53).

This will be fixed in a later commit, and afterwards `kube-api` will be used instead of hardcoded IP's in kubeconfigs and other places.

**Other changes**

The magic string `system:masters` is used for admin CSR to allow the local user to have unrestricted access to `kubectl`.